### PR TITLE
ENG-55870 Encode all extra attributes uniformly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ custom/*
 resources/dev
 .rvmrc
 .bundle
+.idea/
+.ruby-*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,21 +7,23 @@ PATH
       crypt-isaac (~> 0.9.1)
       gettext (~> 2.1.0)
       sinatra (~> 1.0)
+      sinatra-r18n (~> 0.4.9)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.5)
-      activesupport (= 3.0.5)
+    activemodel (3.0.20)
+      activesupport (= 3.0.20)
       builder (~> 2.1.2)
-      i18n (~> 0.4)
-    activerecord (3.0.5)
-      activemodel (= 3.0.5)
-      activesupport (= 3.0.5)
-      arel (~> 2.0.2)
+      i18n (~> 0.5.0)
+    activerecord (3.0.20)
+      activemodel (= 3.0.20)
+      activesupport (= 3.0.20)
+      arel (~> 2.0.10)
       tzinfo (~> 0.3.23)
-    activesupport (3.0.5)
-    arel (2.0.9)
+    activesupport (3.0.20)
+    arel (2.0.10)
+    backports (3.6.7)
     builder (2.1.2)
     capybara (0.4.1.2)
       celerity (>= 0.7.9)
@@ -38,20 +40,19 @@ GEM
     crypt-isaac (0.9.1)
     culerity (0.2.15)
     diff-lcs (1.1.2)
-    ffi (0.6.3)
-      rake (>= 0.8.7)
+    ffi (0.6.4)
     gettext (2.1.0)
       locale (>= 2.0.5)
-    i18n (0.5.0)
+    i18n (0.5.4)
     json_pure (1.5.1)
-    locale (2.0.5)
+    locale (2.1.2)
     mime-types (1.16)
     net-ldap (0.1.1)
     nokogiri (1.4.4)
+    r18n-core (0.4.10)
     rack (1.2.1)
     rack-test (0.5.7)
       rack (>= 1.0)
-    rake (0.8.7)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
       rspec-expectations (~> 2.5.0)
@@ -66,12 +67,16 @@ GEM
       ffi (~> 0.6.3)
       json_pure
       rubyzip
-    sinatra (1.1.3)
-      rack (~> 1.1)
+    sinatra (1.2.9)
+      backports
+      rack (~> 1.1, < 1.5)
       tilt (>= 1.2.2, < 2.0)
+    sinatra-r18n (0.4.10)
+      r18n-core (= 0.4.10)
+      sinatra (>= 0.9)
     sqlite3 (1.3.3)
-    tilt (1.2.2)
-    tzinfo (0.3.24)
+    tilt (1.4.1)
+    tzinfo (0.3.46)
     xpath (0.1.3)
       nokogiri (~> 1.3)
 
@@ -79,15 +84,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 3.0.0)
-  activesupport (~> 3.0.0)
   capybara
-  crypt-isaac (~> 0.9.1)
-  gettext (~> 2.1.0)
   net-ldap (~> 0.1.1)
   rack-test
   rspec
   rspec-core
   rubycas-server!
-  sinatra (~> 1.0)
   sqlite3 (~> 1.3.1)
+
+BUNDLED WITH
+   1.10.5

--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -734,14 +734,8 @@ module CASServer
     end
 
     def serialize_extra_attribute(builder, key, value)
-      if value.kind_of?(String)
-        builder.tag! key, value
-      elsif value.kind_of?(Numeric)
-        builder.tag! key, value.to_s
-      else
-        builder.tag! key do
-          builder.cdata! value.to_yaml
-        end
+      builder.tag! key do
+        builder.cdata! value.to_yaml
       end
     end
 


### PR DESCRIPTION
The way they're currently being encoded amounts to being an undiscriminated union.  The way they're being decoded amounts to guessing what the encoded type was - very poorly.  This change makes all the encoding uniform, and match what the decoder does.
